### PR TITLE
Fix random string generation and test uniqueness

### DIFF
--- a/poll-app-server/src/main/java/poll/app/services/PollServiceImpl.java
+++ b/poll-app-server/src/main/java/poll/app/services/PollServiceImpl.java
@@ -129,10 +129,10 @@ public class PollServiceImpl implements PollService {
 
 	private String generateRandomString(int length) {
 		String str;
-		do {
-			str = RandomStringUtils.randomAlphanumeric(length);
-		} while (pollRepository.existsByCode(str) && voteRepository.existsByCode(str));
-		return RandomStringUtils.randomAlphanumeric(length);
-	}
+               do {
+                       str = RandomStringUtils.randomAlphanumeric(length);
+               } while (pollRepository.existsByCode(str) || voteRepository.existsByCode(str));
+               return str;
+       }
 
 }

--- a/poll-app-server/src/test/java/poll/app/services/PollServiceImplTest.java
+++ b/poll-app-server/src/test/java/poll/app/services/PollServiceImplTest.java
@@ -1,0 +1,40 @@
+package poll.app.services;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+import poll.app.repositories.PollRepository;
+import poll.app.repositories.VoteRepository;
+
+public class PollServiceImplTest {
+
+    @Test
+    public void generateRandomString_producesUniqueCodes() throws Exception {
+        Set<String> usedCodes = new HashSet<>();
+
+        PollRepository pollRepository = mock(PollRepository.class);
+        VoteRepository voteRepository = mock(VoteRepository.class);
+
+        when(pollRepository.existsByCode(anyString())).thenAnswer(inv -> usedCodes.contains(inv.getArgument(0)));
+        when(voteRepository.existsByCode(anyString())).thenAnswer(inv -> usedCodes.contains(inv.getArgument(0)));
+
+        PollServiceImpl service = new PollServiceImpl(pollRepository, null, voteRepository);
+
+        Method method = PollServiceImpl.class.getDeclaredMethod("generateRandomString", int.class);
+        method.setAccessible(true);
+
+        for (int i = 0; i < 100; i++) {
+            String code = (String) method.invoke(service, 8);
+            assertFalse("Duplicate code generated", usedCodes.contains(code));
+            usedCodes.add(code);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- ensure poll and vote codes check use logical OR
- return the generated string instead of creating a new one
- add a test validating that generated codes remain unique

## Testing
- `sh mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686418d39ce88332859e3ee0d3f3daf6