### PR TITLE
Rename endpoint method

### DIFF
--- a/poll-app-server/src/main/java/poll/app/controllers/TimeController.java
+++ b/poll-app-server/src/main/java/poll/app/controllers/TimeController.java
@@ -11,8 +11,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/time")
 @CrossOrigin
 public class TimeController {
-	@GetMapping
-	public LocalDateTime getTimeZone() {
-		return LocalDateTime.now();
-	}
+        @GetMapping
+        // Returns the current server date and time
+        public LocalDateTime getCurrentTime() {
+                return LocalDateTime.now();
+        }
 }


### PR DESCRIPTION
## Summary
- rename `getTimeZone` to `getCurrentTime`
- document that the endpoint returns the server time

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686419f84e148332aa679e9ad7aced9a